### PR TITLE
Upgrade FMP to 4.0.0-M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <maven.min.version>3.3.9</maven.min.version>
     <jdk.min.version>${maven.compiler.source}</jdk.min.version>
 
-    <fabric8-maven-plugin.version>3.5.41</fabric8-maven-plugin.version>
+    <fabric8-maven-plugin.version>4.0.0-M2</fabric8-maven-plugin.version>
     <maven-failsafe-plugin.version>2.22.1</maven-failsafe-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
 


### PR DESCRIPTION
Until the next FMP version is released we can use 4.0.0-M2 for the boosters that require aggregate profile. At least integration tests seem to work fine.